### PR TITLE
ci: configure OIDC authentication for npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/') }}
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
   checks: write
@@ -270,6 +271,7 @@ jobs:
     if: ${{ needs.route.outputs.run_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     steps:
@@ -462,8 +464,6 @@ jobs:
 
       - name: Publish package to npm
         if: steps.versions.outputs.version_changed == 'true' && steps.versions.outputs.allow_publish == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm ci
           npm run build


### PR DESCRIPTION
Add `id-token: write` permissions in `.github/workflows/ci.yml` and remove the static `NPM_TOKEN` secret to configure the CI side of npm's "Trusted Publishers" feature (OIDC authentication).

---
*PR created automatically by Jules for task [9369501200919655382](https://jules.google.com/task/9369501200919655382) started by @arran4*