### PR TITLE
ci: fix push failures on pipeline rerun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "ci: automated formatting fixes"
-          git push origin "$BRANCH"
+          git push -f origin "$BRANCH"
 
           gh pr create \
             --title "ci: automated formatting fixes" \
@@ -329,7 +329,11 @@ jobs:
 
             git add package.json package-lock.json
             git commit -m "chore: bump version to $NEW_VERSION"
-            git push origin HEAD:${{ github.ref_name }}
+            if ! git push origin HEAD:${{ github.ref_name }} 2>/dev/null; then
+              echo "Push failed, attempting to rebase..."
+              git pull --rebase origin ${{ github.ref_name }}
+              git push origin HEAD:${{ github.ref_name }}
+            fi
 
             NEW_SHA=$(git rev-parse HEAD)
             echo "manual_bump_occurred=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Updates `.github/workflows/ci.yml` to properly handle failures when pushing to the remote branch during workflow reruns. Specifically, it implements pull-rebase behavior for the main branch version bump to resolve non-fast-forward errors and force-pushing for the auto-fix branch.

---
*PR created automatically by Jules for task [17484252166140911272](https://jules.google.com/task/17484252166140911272) started by @arran4*