### PR TITLE
ci: update Node to 24 and setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint --if-present
@@ -198,9 +198,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
 
       - name: Run autofix formatters
@@ -282,9 +282,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Configure Git
         run: |
@@ -461,9 +461,9 @@ jobs:
 
       - name: Setup Node.js for publishing
         if: steps.versions.outputs.version_changed == 'true' && steps.versions.outputs.allow_publish == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish package to npm


### PR DESCRIPTION
Updates the GitHub Actions workflow `ci.yml` to use Node 24 and `actions/setup-node@v7` for publishing, testing, formatting, and manual version bump steps. This addresses the misleading E404 error during npm OIDC/trusted-publisher publishing and keeps Node versions consistent across the CI workflow.

---
*PR created automatically by Jules for task [16444335326200719622](https://jules.google.com/task/16444335326200719622) started by @arran4*